### PR TITLE
Add type safety to core classes

### DIFF
--- a/src/main/java/com/redstoneblocks/java/swing_mvc/core/Controller.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/core/Controller.java
@@ -6,9 +6,9 @@ import com.redstoneblocks.java.swing_mvc.util.Navigator;
 /**
  * A base core.Controller class for MVC.
  */
-public abstract class Controller {
-    protected View view;
-    protected Model model;
+public abstract class Controller<V extends View<M>, M extends Model<?>> {
+    protected V view;
+    protected M model;
 
     /**
      * Create the controller with the view and model
@@ -16,7 +16,7 @@ public abstract class Controller {
      * @param view  the view (gui)
      * @param model the model (data)
      */
-    public Controller(View view, Model model) {
+    public Controller(V view, M model) {
         this.view = view;
         this.model = model;
     }
@@ -40,7 +40,7 @@ public abstract class Controller {
      * @return the controllers view
      * @see GUI
      */
-    public View getView() {
+    public V getView() {
         return view;
     }
 

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/core/Model.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/core/Model.java
@@ -3,11 +3,11 @@ package com.redstoneblocks.java.swing_mvc.core;
 /**
  * A base class to designate Models for MVC.
  */
-public abstract class Model {
+public abstract class Model<T> {
     /**
      * This method should initialize the model with a specified state
      *
-     * @param state the object (or null) to be passed to the next screens model
+     * @param state the object (or null) to be passed to the next screen's model
      */
-    public abstract void init(Object state);
+    public abstract void init(T state);
 }

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/core/View.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/core/View.java
@@ -5,14 +5,14 @@ import javax.swing.*;
 /**
  * A class to designate view for MVC.
  */
-abstract public class View {
+abstract public class View<M extends Model<?>> {
 
     /**
      * This method should create the views components
      *
      * @param model the model to base the view off of initially
      */
-    public abstract void create(Model model);
+    public abstract void create(M model);
 
     public abstract JPanel getGui();
 }


### PR DESCRIPTION
The core classes (Model, View, Controller) did not have type safety, and as such, casts had to be used to cast the abstract class to the correct concete class. This was found to not be ergonomic, and required unneeded boilerplate. This PR adds type parameters to the core classes to allow usage without casts. This however, isnt checked to ensure that the type passed matches the type paramter.