### PR TITLE
Add frame configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.redstoneblocks.java</groupId>
     <artifactId>Swing-MVC</artifactId>
-    <version>0.0.4</version>
+    <version>0.1.0</version>
 
     <name>Swing MVC</name>
     <description>A Lightweight MVC Framework for Java Swing</description>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.2.0</version>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/runner/App.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/runner/App.java
@@ -1,36 +1,55 @@
 package com.redstoneblocks.java.swing_mvc.runner;
 
+import com.redstoneblocks.java.swing_mvc.util.FrameConfiguration;
+
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
 /**
  * The entry point of the application
  */
-public class App {
+public class App
+{
+/**
+ * Create the gui and start it with the specified config
+ */
+public static void createAndStart(FrameConfiguration config)
+{
+    GUI gui = new GUI();
+
+    if (config != null)
+        config.config(gui);
+
+    ScreenRegistry.getInstance().addScreensFromClassPath();
+
+    ScreenLifecycleManager manager = new ScreenLifecycleManager(gui);
+
+    try
+    {
+        Screen entryPoint = ScreenRegistry.getInstance().createEntryPoint();
+        manager.switchTo(entryPoint, null);
+    }
+    catch (NoScreensException e)
+    {
+        throw new RuntimeException(e);
+    }
+
+    gui.addWindowListener(new WindowAdapter()
+    {
+        @Override
+        public void windowClosing(WindowEvent e)
+        {
+            manager.cleanUpLifecycles();
+        }
+    });
+
+    gui.setVisible(true);
+}
+
     /**
-     * Create the gui and start it
+     * Create the gui and start it with default config
      */
     public static void createAndStart() {
-        GUI gui = new GUI();
-
-        ScreenRegistry.getInstance().addScreensFromClassPath();
-
-        ScreenLifecycleManager manager = new ScreenLifecycleManager(gui);
-
-        try {
-            Screen entryPoint = ScreenRegistry.getInstance().createEntryPoint();
-            manager.switchTo(entryPoint, null);
-        } catch (NoScreensException e) {
-            throw new RuntimeException(e);
-        }
-
-        gui.addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                manager.cleanUpLifecycles();
-            }
-        });
-
-        gui.setVisible(true);
+        createAndStart(null);
     }
 }

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/runner/App.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/runner/App.java
@@ -11,7 +11,9 @@ import java.awt.event.WindowEvent;
 public class App
 {
 /**
- * Create the gui and start it with the specified config
+ * Create the gui and start it with the specified config.
+ *
+ * @param config the configuration to apply
  */
 public static void createAndStart(FrameConfiguration config)
 {

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
@@ -2,6 +2,14 @@ package com.redstoneblocks.java.swing_mvc.util;
 
 import com.redstoneblocks.java.swing_mvc.runner.GUI;
 
+/**
+ * An interface to allow for configuration of the underlying GUI, which is a subclass of JFrame
+ */
 public interface FrameConfiguration {
+    /**
+     * Run to configure the gui
+     *
+     * @param gui the GUI to configure
+     */
     void config(GUI gui);
 }

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
@@ -2,7 +2,6 @@ package com.redstoneblocks.java.swing_mvc.util;
 
 import com.redstoneblocks.java.swing_mvc.runner.GUI;
 
-public abstract class FrameConfiguration
-{
-    public abstract void config(GUI gui);
+public interface FrameConfiguration {
+    void config(GUI gui);
 }

--- a/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
+++ b/src/main/java/com/redstoneblocks/java/swing_mvc/util/FrameConfiguration.java
@@ -1,0 +1,8 @@
+package com.redstoneblocks.java.swing_mvc.util;
+
+import com.redstoneblocks.java.swing_mvc.runner.GUI;
+
+public abstract class FrameConfiguration
+{
+    public abstract void config(GUI gui);
+}

--- a/src/test/java/com/redstoneblocks/java/swing_mvc/util/FrameConfigurationTest.java
+++ b/src/test/java/com/redstoneblocks/java/swing_mvc/util/FrameConfigurationTest.java
@@ -1,28 +1,23 @@
 package com.redstoneblocks.java.swing_mvc.util;
 
 import com.redstoneblocks.java.swing_mvc.runner.GUI;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.*;
 
 class FrameConfigurationTest {
-    GUI gui;
-
-    @BeforeEach
-    void setupGUI() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
-        Constructor<GUI> constructor = GUI.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        gui = constructor.newInstance();
-    }
-
+    @SuppressWarnings("MagicConstant")
     @Test
     void canConfigureGUI() {
+        GUI gui = mock(GUI.class);
+        doCallRealMethod().when(gui).getDefaultCloseOperation();
+        doCallRealMethod().when(gui).setDefaultCloseOperation(anyInt());
+        gui.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE); // This is set in the default constructor, but we set it here because we are not calling the real constructor
+
         FrameConfiguration configuration = frame -> frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 
         int closeOperation = gui.getDefaultCloseOperation();

--- a/src/test/java/com/redstoneblocks/java/swing_mvc/util/FrameConfigurationTest.java
+++ b/src/test/java/com/redstoneblocks/java/swing_mvc/util/FrameConfigurationTest.java
@@ -1,0 +1,35 @@
+package com.redstoneblocks.java.swing_mvc.util;
+
+import com.redstoneblocks.java.swing_mvc.runner.GUI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class FrameConfigurationTest {
+    GUI gui;
+
+    @BeforeEach
+    void setupGUI() throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        Constructor<GUI> constructor = GUI.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        gui = constructor.newInstance();
+    }
+
+    @Test
+    void canConfigureGUI() {
+        FrameConfiguration configuration = frame -> frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+
+        int closeOperation = gui.getDefaultCloseOperation();
+        assertNotEquals(WindowConstants.DO_NOTHING_ON_CLOSE, closeOperation);
+
+        configuration.config(gui);
+
+        assertEquals(WindowConstants.DO_NOTHING_ON_CLOSE, gui.getDefaultCloseOperation());
+    }
+}


### PR DESCRIPTION
Swing-MVC has had a problem: there was no direct access to the internal JFrame. This meant you could not resize the gui, or have a diffent close operation. This PR adds a FrameConfiguration class, and a new method in App that allows for configuration to be done before the application loads. This enables the above uscases, among others. This PR is fully backwards compatiable, and should not require changes to dependant source code.